### PR TITLE
Added tracking camera motion + zoom out depending on pet's state

### DIFF
--- a/Frankenpets/Assets/Scripts/CameraMovement.cs
+++ b/Frankenpets/Assets/Scripts/CameraMovement.cs
@@ -2,12 +2,46 @@ using UnityEngine;
 
 public class CameraMovement : MonoBehaviour
 {
-    public Transform pet;
+    [Header("References")]
+    public Camera mainCamera;
+    public Transform frontHalf;
+
+    [Header("Camera Details")]
+    public int fieldOfViewConnected = 49;
+    public int fieldOfViewDisconnected = 120;
+    public Vector3 zoomOutPosition = new Vector3(-16.759f, 0.767f, -22.652f);
+    public Vector3 zoomInAdjustment = new Vector3(1.0f, 0.8f, 2.25f);
+
+    private FixedJoint fixedJoint;
+    private bool zoomOut = false;
 
     // Update is called once per frame
     void Update()
     {
-        // need to change
-        transform.position = pet.transform.position + new Vector3(0, 0, 0);
+        fixedJoint = frontHalf.GetComponent<FixedJoint>();
+
+        // If connected, camera zooms in and follows the pet
+        if (fixedJoint != null)
+        {
+            mainCamera.fieldOfView = fieldOfViewConnected;
+            mainCamera.transform.position = frontHalf.position + zoomInAdjustment;
+        }
+        else
+        {
+            zoomOut = true;
+        }
+    }
+
+    void FixedUpdate()
+    {
+        if (zoomOut)
+        {
+            // If no FixedJoint, zoom out the camera and set its position
+            mainCamera.fieldOfView = fieldOfViewDisconnected;
+            
+            // Move the camera to the specified position
+            mainCamera.transform.position = zoomOutPosition;
+            zoomOut = false;
+        }
     }
 }


### PR DESCRIPTION
**Description**
Camera should track the pet when connected and zoom out to the initial fixed angle/field of view when not. 

**Related Tasks**
#37 

**Set-Up & Testing**
Create an empty GameObject in the hierarchy and name it CameraController. Drag the CameraMovement.cs script onto the game object. Once done, add the following References in the inspector:
- Main Camera: Add the camera in the scene. 
- Front Half: Front half of the cat(or pet when we get more models)

**Next Steps**

1. Walls Obstructing Camera
2. Set camera bounds.