### PR TITLE
Climbing Rig

### DIFF
--- a/Frankenpets/Assets/Prefabs/Character/Rigged/catFront.prefab
+++ b/Frankenpets/Assets/Prefabs/Character/Rigged/catFront.prefab
@@ -1332,6 +1332,7 @@ GameObject:
   - component: {fileID: 4983427169298448593}
   - component: {fileID: 1685690688004923698}
   - component: {fileID: 7177464260336249629}
+  - component: {fileID: 6505666236130877673}
   m_Layer: 10
   m_Name: catFront
   m_TagString: cat front
@@ -1358,6 +1359,7 @@ Transform:
   - {fileID: 2635682467137375184}
   - {fileID: 3546588009761302104}
   - {fileID: 2746014764797832635}
+  - {fileID: 4315826866464884758}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!54 &5621999223544513318
@@ -1493,6 +1495,58 @@ MonoBehaviour:
   - m_Rig: {fileID: 2667701740022929785}
     m_Active: 1
   m_Effectors: []
+--- !u!114 &6505666236130877673
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6639889057943378382}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f968ac5fab9d74b61b03befb382e294a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  orientation: {fileID: 0}
+  rb: {fileID: 5621999223544513318}
+  ClimbingWall:
+    serializedVersion: 2
+    m_Bits: 4096
+  climbSpeed: 0.5
+  detectionLength: 0.5
+  sphereCastRadius: 0.1
+  maxWallLookAngle: 30
+--- !u!1 &7036805894374920876
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4315826866464884758}
+  m_Layer: 10
+  m_Name: orientation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4315826866464884758
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7036805894374920876}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.1463, z: 0.1374}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5879117073093705848}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7795189940345508176
 GameObject:
   m_ObjectHideFlags: 0

--- a/Frankenpets/Assets/Prefabs/Character/Rigged/catFront.prefab
+++ b/Frankenpets/Assets/Prefabs/Character/Rigged/catFront.prefab
@@ -1507,7 +1507,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f968ac5fab9d74b61b03befb382e294a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  orientation: {fileID: 0}
+  orientation: {fileID: 4315826866464884758}
   rb: {fileID: 5621999223544513318}
   ClimbingWall:
     serializedVersion: 2

--- a/Frankenpets/Assets/Scripts/ClimbMovement.cs
+++ b/Frankenpets/Assets/Scripts/ClimbMovement.cs
@@ -1,0 +1,90 @@
+using UnityEngine;
+using UnityEngine.Animations.Rigging;
+using System.Collections;
+
+public class ClimbMovement: MonoBehaviour
+{
+    [Header("References")]
+    public Transform orientation;
+    public Rigidbody rb;
+    public LayerMask ClimbingWall;
+
+    [Header("Climbing")]
+    public float climbSpeed;
+
+    private bool climbing;
+
+    [Header("Detection")]
+    public float detectionLength;
+    public float sphereCastRadius;
+    public float maxWallLookAngle;
+    private float wallLookAngle;
+
+    private RaycastHit frontWallHit;
+    private bool wallFront;
+
+    public bool checkClimb()
+    {
+        WallCheck();
+        StateMachine();
+        //if (climbing) ClimbingMovement();
+
+        if (climbing){
+            UnityEngine.Debug.Log("climbing is true");
+        } else{
+            UnityEngine.Debug.Log("climbing is false;");
+        }
+
+        return climbing;
+    }
+
+    private void StateMachine()
+    {
+        UnityEngine.Debug.Log("checking state machine");
+        if (wallFront && wallLookAngle < maxWallLookAngle){
+            climbing = true;
+            
+        }
+        else{
+            UnityEngine.Debug.Log("angle not smaller");
+            if (climbing){
+                climbing = false;
+            }
+        }
+    }
+    private void OnDrawGizmos()
+    {
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, sphereCastRadius);
+        Gizmos.DrawLine(transform.position, transform.position + orientation.forward * detectionLength); // Direction
+    }
+
+    private void WallCheck()
+    {
+        UnityEngine.Debug.Log("checking wall");
+        
+
+        wallFront = Physics.SphereCast(transform.position, sphereCastRadius, orientation.forward, out frontWallHit, detectionLength, ClimbingWall);
+        wallLookAngle = Vector3.Angle(orientation.forward, -frontWallHit.normal);
+
+        if (wallFront){
+            UnityEngine.Debug.Log("wall if front");
+        } else{
+            UnityEngine.Debug.Log("wall not front");
+        }
+        UnityEngine.Debug.Log("wall look angle: " + wallLookAngle);
+
+        
+    }
+
+    public void ClimbingMovement()
+    {
+        rb.linearVelocity = new Vector3(rb.linearVelocity.x, climbSpeed, rb.linearVelocity.z);
+    }
+
+
+
+
+
+
+}

--- a/Frankenpets/Assets/Scripts/ClimbMovement.cs
+++ b/Frankenpets/Assets/Scripts/ClimbMovement.cs
@@ -6,11 +6,7 @@ public class ClimbMovement: MonoBehaviour
 {
     [Header("References")]
     public Transform orientation;
-    public Rigidbody rb;
     public LayerMask ClimbingWall;
-
-    [Header("Climbing")]
-    public float climbSpeed;
 
     private bool climbing;
 
@@ -27,7 +23,6 @@ public class ClimbMovement: MonoBehaviour
     {
         WallCheck();
         StateMachine();
-        //if (climbing) ClimbingMovement();
 
         if (climbing){
             UnityEngine.Debug.Log("climbing is true");
@@ -76,12 +71,6 @@ public class ClimbMovement: MonoBehaviour
 
         
     }
-
-    public void ClimbingMovement()
-    {
-        rb.linearVelocity = new Vector3(rb.linearVelocity.x, climbSpeed, rb.linearVelocity.z);
-    }
-
 
 
 

--- a/Frankenpets/Assets/Scripts/ClimbMovement.cs.meta
+++ b/Frankenpets/Assets/Scripts/ClimbMovement.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f968ac5fab9d74b61b03befb382e294a

--- a/Frankenpets/Assets/Scripts/PlayerActions.cs
+++ b/Frankenpets/Assets/Scripts/PlayerActions.cs
@@ -393,9 +393,6 @@ public class PlayerActions : MonoBehaviour
         climbRiggingScript.climb();
         isClimbing = true;
 
-        //climbMovementScript.ClimbingMovement();
-
-        ////
         frontRb.useGravity = false;
         // Zero out current velocities
         frontRb.linearVelocity = Vector3.zero;

--- a/Frankenpets/Assets/Scripts/PlayerActions.cs
+++ b/Frankenpets/Assets/Scripts/PlayerActions.cs
@@ -38,6 +38,7 @@ public class PlayerActions : MonoBehaviour
     private bool isNearClimbable = false;
     private bool isClimbing = false;
     private Vector3 climbDirection;
+    private ClimbMovement climbMovementScript;
     // private GameObject climbText;
 
     // Grabbing Variables
@@ -49,8 +50,6 @@ public class PlayerActions : MonoBehaviour
     private Vector3 mouthPosition;
     private Vector3 mouthDirection;
     private Vector3 grabPoint; // Position where the joint connects
-
-    
 
     private GrabPoint currentGrabPoint;
     private GrabbableObject currentGrabbableObject;
@@ -180,6 +179,7 @@ public class PlayerActions : MonoBehaviour
             showClimbText();
 
             isNearClimbable = true;
+
             // Get the surface normal to determine climb direction
             if (Physics.Raycast(transform.position, other.transform.position - transform.position, out RaycastHit hit, climbCheckDistance))
             {
@@ -249,6 +249,7 @@ public class PlayerActions : MonoBehaviour
             frontRb = frontHalf.GetComponent<Rigidbody>();
             backRb = backHalf.GetComponent<Rigidbody>();
 
+            climbMovementScript = frontHalf.GetComponentInChildren<ClimbMovement>();
             mouthRiggingScript = frontHalf.GetComponentInChildren<MouthRigging>();
             tailRiggingScript = backHalf.GetComponentInChildren<TailRigging>();
             pawRiggingScript = frontHalf.GetComponentInChildren<PawRigging>();
@@ -363,16 +364,20 @@ public class PlayerActions : MonoBehaviour
         // Check for cat species in front position
         string frontSpecies = P1.IsFront ? P1.Species : P2.Species;
         bool isSpecialReleased = (P1.IsFront && !player1Special) || (P2.IsFront && !player2Special);
-        
+
         // Only cats can climb
         if (frontSpecies != "cat") return;
-        
-        // Start climbing when front cat player presses special near climbable
+
+        //Start climbing when front cat player presses special near climbable
         if (isNearClimbable && !isClimbing)
         {
             if ((player1Special && P1.IsFront) || (player2Special && P2.IsFront))
             {
-                StartClimbing();
+                
+                if (climbMovementScript.checkClimb()){
+                    StartClimbing();
+                }
+                
             }
         }
         // Stop climbing when button is released
@@ -384,10 +389,13 @@ public class PlayerActions : MonoBehaviour
 
     private void StartClimbing()
     {
-        
+        UnityEngine.Debug.Log("in start climbing function");
         climbRiggingScript.climb();
-
         isClimbing = true;
+
+        //climbMovementScript.ClimbingMovement();
+
+        ////
         frontRb.useGravity = false;
         // Zero out current velocities
         frontRb.linearVelocity = Vector3.zero;
@@ -398,6 +406,7 @@ public class PlayerActions : MonoBehaviour
 
     private void StopClimbing()
     {
+        UnityEngine.Debug.Log("in end climbing function");
         climbRiggingScript.release();
         isClimbing = false;
         frontRb.useGravity = true;

--- a/Frankenpets/ProjectSettings/TagManager.asset
+++ b/Frankenpets/ProjectSettings/TagManager.asset
@@ -30,7 +30,7 @@ TagManager:
   - GrabbableLayer
   - Pet
   - Floor
-  - 
+  - ClimbingWall
   - 
   - 
   - 


### PR DESCRIPTION
This PR includes changes to detect the pet's current facing angle to enable climbing. Player would have to be facing the wall in order for climbing to be activated aside from just being close to it. Climbable surfaces would have to have the 'ClimbingWall' layer enabled for the raycast to detect it. 